### PR TITLE
SO1S-372 Istio Namespace Injection 코드 추가

### DIFF
--- a/charts/backend/templates/pre-install/clusterrolebinding.yaml
+++ b/charts/backend/templates/pre-install/clusterrolebinding.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: namespace-labeler
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/backend/templates/pre-install/clusterrolebinding.yaml
+++ b/charts/backend/templates/pre-install/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: namespace-labeler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: hyper-sa
+    namespace: {{ .Release.Namespace  }}

--- a/charts/backend/templates/pre-install/namespace.yaml
+++ b/charts/backend/templates/pre-install/namespace.yaml
@@ -9,8 +9,8 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
   template:
     metadata:
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
       serviceAccountName: hyper-sa
@@ -31,5 +33,5 @@ spec:
             memory: 100Mi
         command: ["/bin/bash", "-c"]
         args:
-          - kubectl label ns default istio-injection=enabled;
-            kubectl label ns {{ .Release.Namespace }} istio-injection=enabled;
+          - kubectl label ns default istio-injection=enabled --overwrite;
+            kubectl label ns {{ .Release.Namespace }} istio-injection=enabled --overwrite;

--- a/charts/backend/templates/pre-install/namespace.yaml
+++ b/charts/backend/templates/pre-install/namespace.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: hyper-sa
+      containers:
+      - name: labeler
+        image: gcr.io/google_containers/hyperkube:v1.9.7
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100Mi
+        command: ["/bin/bash", "-c"]
+        args:
+          - kubectl label ns default istio-injection=enabled;
+            kubectl label ns {{ .Release.Namespace }} istio-injection=enabled;

--- a/charts/backend/templates/pre-install/serviceaccount.yaml
+++ b/charts/backend/templates/pre-install/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hyper-sa

--- a/charts/backend/templates/pre-install/serviceaccount.yaml
+++ b/charts/backend/templates/pre-install/serviceaccount.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hyper-sa
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded


### PR DESCRIPTION
# Istio Namespace Injection 코드 추가

istio proxy 사이드카가 생성되기 위해서는 Namespace에 특정 라벨을 붙여줘야합니다. 그러나 helm에서는 단순히 네임스페이스만 생성할뿐 라벨을 붙이는 등의 커스텀은 할 수 없습니다. 따라서 helm pre install와 hyperkube 컨테이너를 통해 네임스페이스를 동적으로 커스텀 해주도록 했습니다.

## Tasks

- [x]  backend 차트 내 pre install 설정 추가


## Discussion

## Jira

- SO1S-372