### PR TITLE
SO1S-478 Tracing Service Kiali 연동

### DIFF
--- a/apps/dev/app-backend.yaml
+++ b/apps/dev/app-backend.yaml
@@ -14,7 +14,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: charts/backend
 

--- a/apps/dev/app-database.yaml
+++ b/apps/dev/app-database.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: charts/database
 

--- a/apps/dev/app-frontend.yaml
+++ b/apps/dev/app-frontend.yaml
@@ -14,7 +14,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: charts/frontend
 

--- a/apps/dev/app-istio.yaml
+++ b/apps/dev/app-istio.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: charts/istio
 

--- a/apps/dev/app-logging.yaml
+++ b/apps/dev/app-logging.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: charts/logging
 

--- a/apps/dev/app-monitoring.yaml
+++ b/apps/dev/app-monitoring.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: charts/monitoring
 

--- a/apps/prod/app-backend.yaml
+++ b/apps/prod/app-backend.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: charts/backend
 

--- a/apps/prod/app-database.yaml
+++ b/apps/prod/app-database.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: charts/database
 

--- a/apps/prod/app-frontend.yaml
+++ b/apps/prod/app-frontend.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: charts/frontend
 

--- a/apps/prod/app-istio.yaml
+++ b/apps/prod/app-istio.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: charts/istio
 

--- a/apps/prod/app-logging.yaml
+++ b/apps/prod/app-logging.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: charts/logging
 

--- a/apps/prod/app-monitoring.yaml
+++ b/apps/prod/app-monitoring.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: charts/monitoring
 

--- a/charts/istio/Chart.lock
+++ b/charts/istio/Chart.lock
@@ -8,5 +8,11 @@ dependencies:
 - name: istiod
   repository: ""
   version: 1.14.2
-digest: sha256:d468f1595fb447a9287b474e0f35023cb433885372fe97c7d21847aa54dc6261
-generated: "2022-09-05T13:01:45.35802856+09:00"
+- name: kiali-server
+  repository: https://kiali.org/helm-charts
+  version: 1.58.0
+- name: kiali-operator
+  repository: https://kiali.org/helm-charts
+  version: 1.58.0
+digest: sha256:1bdd6b1f37bec27f48aaca5fd55972c5b9200f2f2a636c8009f48730403eea97
+generated: "2022-11-03T08:10:49.346197704+09:00"

--- a/charts/istio/Chart.lock
+++ b/charts/istio/Chart.lock
@@ -9,10 +9,10 @@ dependencies:
   repository: ""
   version: 1.14.2
 - name: kiali-server
-  repository: https://kiali.org/helm-charts
+  repository: ""
   version: 1.58.0
 - name: kiali-operator
-  repository: https://kiali.org/helm-charts
+  repository: ""
   version: 1.58.0
-digest: sha256:1bdd6b1f37bec27f48aaca5fd55972c5b9200f2f2a636c8009f48730403eea97
-generated: "2022-11-03T08:10:49.346197704+09:00"
+digest: sha256:7094030fc3d77aae5e7ef4501cb52fc58840b941abdc74198a15abee52116c0d
+generated: "2022-11-03T08:46:55.450496862+09:00"

--- a/charts/istio/Chart.lock
+++ b/charts/istio/Chart.lock
@@ -10,9 +10,9 @@ dependencies:
   version: 1.14.2
 - name: kiali-server
   repository: ""
-  version: 1.58.0
+  version: 1.54.0
 - name: kiali-operator
   repository: ""
-  version: 1.58.0
-digest: sha256:7094030fc3d77aae5e7ef4501cb52fc58840b941abdc74198a15abee52116c0d
-generated: "2022-11-03T08:46:55.450496862+09:00"
+  version: 1.54.0
+digest: sha256:de6686170700d2666d961184e6cab034c548278ff1a1577e3a7a4e257b695460
+generated: "2022-11-03T08:52:00.145235055+09:00"

--- a/charts/istio/Chart.yaml
+++ b/charts/istio/Chart.yaml
@@ -23,8 +23,6 @@ dependencies:
   - name: istiod
     version: 1.14.2
   - name: kiali-server
-    repository: "https://kiali.org/helm-charts"
     version: 1.58.0
   - name: kiali-operator
-    repository: "https://kiali.org/helm-charts"
     version: 1.58.0

--- a/charts/istio/Chart.yaml
+++ b/charts/istio/Chart.yaml
@@ -22,3 +22,9 @@ dependencies:
     version: 1.14.2
   - name: istiod
     version: 1.14.2
+  - name: kiali-server
+    repository: "https://kiali.org/helm-charts"
+    version: 1.58.0
+  - name: kiali-operator
+    repository: "https://kiali.org/helm-charts"
+    version: 1.58.0

--- a/charts/istio/Chart.yaml
+++ b/charts/istio/Chart.yaml
@@ -23,6 +23,6 @@ dependencies:
   - name: istiod
     version: 1.14.2
   - name: kiali-server
-    version: 1.58.0
+    version: 1.54.0
   - name: kiali-operator
-    version: 1.58.0
+    version: 1.54.0

--- a/charts/istio/charts/kiali-operator/Chart.yaml
+++ b/charts/istio/charts/kiali-operator/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
-appVersion: v1.58.0
-description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+appVersion: v1.54.0
+description: Kiali is an open source project for service mesh observability, refer
+  to https://www.kiali.io for details.
 home: https://github.com/kiali/kiali-operator
 icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
 keywords:
@@ -16,4 +17,4 @@ sources:
 - https://github.com/kiali/kiali
 - https://github.com/kiali/kiali-operator
 - https://github.com/kiali/helm-charts
-version: 1.58.0
+version: 1.54.0

--- a/charts/istio/charts/kiali-operator/Chart.yaml
+++ b/charts/istio/charts/kiali-operator/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+appVersion: v1.58.0
+description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+home: https://github.com/kiali/kiali-operator
+icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
+keywords:
+- istio
+- kiali
+- operator
+maintainers:
+- email: kiali-users@googlegroups.com
+  name: Kiali
+  url: https://kiali.io
+name: kiali-operator
+sources:
+- https://github.com/kiali/kiali
+- https://github.com/kiali/kiali-operator
+- https://github.com/kiali/helm-charts
+version: 1.58.0

--- a/charts/istio/charts/kiali-operator/crds/crds.yaml
+++ b/charts/istio/charts/kiali-operator/crds/crds.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+...

--- a/charts/istio/charts/kiali-operator/templates/NOTES.txt
+++ b/charts/istio/charts/kiali-operator/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Welcome to Kiali! For more details on Kiali, see: https://kiali.io
+
+The Kiali Operator [{{ .Chart.AppVersion }}] has been installed in namespace [{{ .Release.Namespace }}]. It will be ready soon.
+
+{{- if .Values.cr.create }}
+  {{- if or (and (not .Values.watchNamespace) (not .Values.cr.namespace)) (and (.Values.watchNamespace) (eq .Values.watchNamespace .Release.Namespace)) (and (.Values.cr.namespace) (eq .Values.cr.namespace .Release.Namespace)) }}
+You have elected to install a Kiali CR in the same namespace as the operator [{{ .Release.Namespace }}]. You should be able to access Kiali soon.
+
+================================
+PLEASE READ THIS WARNING NOTICE:
+Because the Kiali CR lives in the same namespace as the operator, DO NOT uninstall the operator or delete the operator namespace without first removing the Kiali CR. If you do not follow this advice then the Kiali Operator deletion will hang indefinitely until you remove the finalizer from the Kiali CR, and then you may find your Kubernetes environment still has Kiali Server remnants left behind.
+================================
+  {{- else if .Values.watchNamespace }}
+You have elected to install a Kiali CR in the operator watch namespace [{{ .Values.watchNamespace }}]. You should be able to access Kiali soon.
+  {{- else if .Values.cr.namespace }}
+You have elected to install a Kiali CR in the namespace [{{ .Values.cr.namespace }}]. You should be able to access Kiali soon.
+  {{- else }}
+You have elected to install a Kiali CR. You should be able to access Kiali soon.
+  {{- end }}
+{{- else }}
+  {{- if (not .Values.watchNamespace) }}
+You have elected not to install a Kiali CR. You must first install a Kiali CR before you can access Kiali. The operator is watching all namespaces, so you can create the Kiali CR anywhere.
+  {{- else }}
+You have elected not to install a Kiali CR. You must first install a Kiali CR in the operator watch namespace [{{ .Values.watchNamespace }}] before you can access Kiali.
+  {{- end }}
+{{- end }}
+
+If you ever want to uninstall the Kiali Operator, remember to delete the Kiali CR first before uninstalling the operator to give the operator a chance to uninstall and remove all the Kiali Server resources.
+
+(Helm: Chart=[{{ .Chart.Name }}], Release=[{{ .Release.Name }}], Version=[{{ .Chart.Version }}])

--- a/charts/istio/charts/kiali-operator/templates/_helpers.tpl
+++ b/charts/istio/charts/kiali-operator/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kiali-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kiali-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kiali-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kiali-operator.labels" -}}
+helm.sh/chart: {{ include "kiali-operator.chart" . }}
+app: {{ include "kiali-operator.name" . }}
+{{ include "kiali-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: "kiali-operator"
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kiali-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kiali-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/istio/charts/kiali-operator/templates/clusterrole.yaml
+++ b/charts/istio/charts/kiali-operator/templates/clusterrole.yaml
@@ -250,9 +250,6 @@ rules:
   - authentication.istio.io
   - rbac.istio.io
   - security.istio.io
-  - extensions.istio.io
-  - telemetry.istio.io
-  - gateway.networking.k8s.io
   resources: ["*"]
   verbs:
   - get

--- a/charts/istio/charts/kiali-operator/templates/clusterrole.yaml
+++ b/charts/istio/charts/kiali-operator/templates/clusterrole.yaml
@@ -1,0 +1,291 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - pods
+  - serviceaccounts
+  - services
+  - services/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - create
+  - list
+  - watch
+{{- if gt (len .Values.secretReader) 0 }}
+- apiGroups: [""]
+  resourceNames:
+  {{- range .Values.secretReader }}
+  - {{ . }}
+  {{- end }}
+  resources:
+  - secrets
+  verbs:
+  - get
+{{- end }}
+- apiGroups: [""]
+  resourceNames:
+  - kiali-signing-key
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups: ["apps"]
+  resourceNames:
+  - kiali-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups: ["kiali.io"]
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - list
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  {{- if or (and (.Values.cr.create) (has "**" .Values.cr.spec.deployment.accessible_namespaces)) (.Values.clusterRoleCreator) }}
+  - clusterrolebindings
+  - clusterroles
+  {{- end }}
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["apiextensions.k8s.io"]
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["oauth.openshift.io"]
+  resources:
+  - oauthclients
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["config.openshift.io"]
+  resources:
+  - clusteroperators
+  verbs:
+  - list
+  - watch
+- apiGroups: ["config.openshift.io"]
+  resourceNames:
+  - kube-apiserver
+  resources:
+  - clusteroperators
+  verbs:
+  - get
+- apiGroups: ["console.openshift.io"]
+  resources:
+  - consolelinks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups:
+  - config.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - create
+  - delete
+  - patch
+  {{- end }}
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+...

--- a/charts/istio/charts/kiali-operator/templates/clusterrolebinding.yaml
+++ b/charts/istio/charts/kiali-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kiali-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kiali-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+...

--- a/charts/istio/charts/kiali-operator/templates/deployment.yaml
+++ b/charts/istio/charts/kiali-operator/templates/deployment.yaml
@@ -45,16 +45,9 @@ spec:
         - "--zap-log-level=info"
         - "--leader-election-id={{ include "kiali-operator.fullname" . }}"
         securityContext:
-        {{- if .Values.securityContext }}
-        {{- toYaml .Values.securityContext | nindent 10 }}
-        {{- else }}
           allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-        {{- end }}
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
@@ -73,8 +66,6 @@ spec:
           value: {{ .Values.allowAdHocKialiNamespace | quote }}
         - name: ALLOW_AD_HOC_KIALI_IMAGE
           value: {{ .Values.allowAdHocKialiImage | quote }}
-        - name: ALLOW_SECURITY_CONTEXT_OVERRIDE
-          value: {{ .Values.allowSecurityContextOverride | quote }}
         - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
           value: "100"
         - name: ANSIBLE_DEBUG_LOGS

--- a/charts/istio/charts/kiali-operator/templates/deployment.yaml
+++ b/charts/istio/charts/kiali-operator/templates/deployment.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+    {{- include "kiali-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      name: {{ include "kiali-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      labels:
+        # required for the operator SDK metric service selector
+        name: {{ include "kiali-operator.fullname" . }}
+      {{- include "kiali-operator.labels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: {{ .Values.metrics.enabled | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    {{- end }}
+    spec:
+      serviceAccountName: {{ include "kiali-operator.fullname" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: operator
+        image: "{{ .Values.image.repo }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ end }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+        args:
+        - "--zap-log-level=info"
+        - "--leader-election-id={{ include "kiali-operator.fullname" . }}"
+        securityContext:
+        {{- if .Values.securityContext }}
+        {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- else }}
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
+        volumeMounts:
+        - mountPath: /tmp/ansible-operator/runner
+          name: runner
+        env:
+        - name: WATCH_NAMESPACE
+          value: {{ .Values.watchNamespace | default "\"\""  }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ALLOW_AD_HOC_KIALI_NAMESPACE
+          value: {{ .Values.allowAdHocKialiNamespace | quote }}
+        - name: ALLOW_AD_HOC_KIALI_IMAGE
+          value: {{ .Values.allowAdHocKialiImage | quote }}
+        - name: ALLOW_SECURITY_CONTEXT_OVERRIDE
+          value: {{ .Values.allowSecurityContextOverride | quote }}
+        - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+          value: "100"
+        - name: ANSIBLE_DEBUG_LOGS
+          value: {{ .Values.debug.enabled | quote }}
+        - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
+          value: {{ .Values.debug.verbosity | quote }}
+        - name: ANSIBLE_CONFIG
+        {{- if .Values.debug.enableProfiler }}
+          value: "/opt/ansible/ansible-profiler.cfg"
+        {{- else }}
+          value: "/etc/ansible/ansible.cfg"
+        {{- end }}
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        {{- if .Values.resources }}
+        resources:
+        {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+      volumes:
+      - name: runner
+        emptyDir: {}
+      affinity:
+      {{- toYaml .Values.affinity | nindent 8 }}
+...

--- a/charts/istio/charts/kiali-operator/templates/kiali-cr.yaml
+++ b/charts/istio/charts/kiali-operator/templates/kiali-cr.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.cr.create }}
+---
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  {{- if .Values.watchNamespace }}
+  namespace: {{ .Values.watchNamespace }}
+  {{- else if .Values.cr.namespace }}
+  namespace: {{ .Values.cr.namespace }}
+  {{- end }}
+  name: {{ .Values.cr.name }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+  annotations:
+    ansible.sdk.operatorframework.io/verbosity: {{ .Values.debug.verbosity | quote }}
+    {{- if .Values.cr.annotations }}
+    {{- toYaml .Values.cr.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- toYaml .Values.cr.spec | nindent 2 }}
+...
+{{ end }}

--- a/charts/istio/charts/kiali-operator/templates/serviceaccount.yaml
+++ b/charts/istio/charts/kiali-operator/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+...

--- a/charts/istio/charts/kiali-operator/values.yaml
+++ b/charts/istio/charts/kiali-operator/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 image: # see: https://quay.io/repository/kiali/kiali-operator?tab=tags
   repo: quay.io/kiali/kiali-operator # quay.io/kiali/kiali-operator
-  tag: v1.58.0 # version string like v1.39.0 or a digest hash
+  tag: v1.54.0 # version string like v1.39.0 or a digest hash
   digest: "" # use "sha256" if tag is a sha256 hash (do NOT prefix this value with a "@")
   pullPolicy: Always
   pullSecrets: []
@@ -20,7 +20,6 @@ resources:
 affinity: {}
 replicaCount: 1
 priorityClassName: ""
-securityContext: {}
 
 # metrics.enabled: set to true if you want Prometheus to collect metrics from the operator
 metrics:
@@ -67,11 +66,6 @@ allowAdHocKialiNamespace: true
 # Kiali CR spec.deployment.image_name and spec.deployment.image_version to be configured by the user.
 # You may want to disable this if you do not want users to install their own Kiali images.
 allowAdHocKialiImage: false
-
-# allowSecurityContextOverride tells the operator to allow a user to be able to fully override the Kiali
-# container securityContext. If this is false, certain securityContext settings must exist on the Kiali
-# container and any attempt to override them will be ignored.
-allowSecurityContextOverride: false
 
 # For what a Kiali CR spec can look like, see:
 # https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml

--- a/charts/istio/charts/kiali-operator/values.yaml
+++ b/charts/istio/charts/kiali-operator/values.yaml
@@ -1,0 +1,92 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image: # see: https://quay.io/repository/kiali/kiali-operator?tab=tags
+  repo: quay.io/kiali/kiali-operator # quay.io/kiali/kiali-operator
+  tag: v1.58.0 # version string like v1.39.0 or a digest hash
+  digest: "" # use "sha256" if tag is a sha256 hash (do NOT prefix this value with a "@")
+  pullPolicy: Always
+  pullSecrets: []
+
+# Deployment options for the operator pod.
+nodeSelector: {}
+podAnnotations: {}
+env: []
+tolerations: []
+resources:
+  requests:
+    cpu: "10m"
+    memory: "64Mi"
+affinity: {}
+replicaCount: 1
+priorityClassName: ""
+securityContext: {}
+
+# metrics.enabled: set to true if you want Prometheus to collect metrics from the operator
+metrics:
+  enabled: true
+
+# debug.enabled: when true the full ansible logs are dumped after each reconciliation run
+# debug.verbosity: defines the amount of details the operator will log (higher numbers are more noisy)
+# debug.enableProfiler: when true (regardless of debug.enabled), timings for the most expensive tasks will be logged after each reconciliation loop
+debug:
+  enabled: true
+  verbosity: "1"
+  enableProfiler: false
+
+# Defines where the operator will look for Kial CR resources. "" means "all namespaces".
+watchNamespace: ""
+
+# Set to true if you want the operator to be able to create cluster roles. This is necessary
+# if you want to support Kiali CRs with spec.deployment.accessible_namespaces of '**'.
+# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
+clusterRoleCreator: true
+
+# Set to a list of secrets in the cluster that the operator will be allowed to read. This is necessary if you want to
+# support Kiali CRs with spec.kiali_feature_flags.certificates_information_indicators.enabled=true.
+# The secrets in this list will be the only ones allowed to be specified in any Kiali CR (in the setting
+# spec.kiali_feature_flags.certificates_information_indicators.secrets).
+# If you set this to an empty list, the operator will not be given permission to read any additional secrets
+# found in the cluster, and thus will only support a value of "false" in the Kiali CR setting
+# spec.kiali_feature_flags.certificates_information_indicators.enabled.
+secretReader: ['cacerts', 'istio-ca-secret']
+
+# Set to true if you want to allow the operator to only be able to install Kiali in view-only-mode.
+# The purpose for this setting is to allow you to restrict the permissions given to the operator itself.
+onlyViewOnlyMode: false
+
+# allowAdHocKialiNamespace tells the operator to allow a user to be able to install a Kiali CR in one namespace but
+# be able to install Kiali in another namespace. In other words, it will allow the Kiali CR spec.deployment.namespace
+# to be something other than the namespace where the CR is installed. You may want to disable this if you are
+# running in a multi-tenant scenario in which you only want a user to be able to install Kiali in the same namespace
+# where the user has permissions to install a Kiali CR.
+allowAdHocKialiNamespace: true
+
+# allowAdHocKialiImage tells the operator to allow a user to be able to install a custom Kiali image as opposed
+# to the image the operator will install by default. In other words, it will allow the
+# Kiali CR spec.deployment.image_name and spec.deployment.image_version to be configured by the user.
+# You may want to disable this if you do not want users to install their own Kiali images.
+allowAdHocKialiImage: false
+
+# allowSecurityContextOverride tells the operator to allow a user to be able to fully override the Kiali
+# container securityContext. If this is false, certain securityContext settings must exist on the Kiali
+# container and any attempt to override them will be ignored.
+allowSecurityContextOverride: false
+
+# For what a Kiali CR spec can look like, see:
+# https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml
+cr:
+  create: false
+  name: kiali
+  # If you elect to create a Kiali CR (--set cr.create=true)
+  # and the operator is watching all namespaces (--set watchNamespace="")
+  # then this is the namespace where the CR will be created (the default will be the operator namespace).
+  namespace: ""
+
+  # Annotations to place in the Kiali CR metadata.
+  annotations: {}
+
+  spec:
+    deployment:
+      accessible_namespaces:
+      - '**'

--- a/charts/istio/charts/kiali-server/Chart.yaml
+++ b/charts/istio/charts/kiali-server/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: v1.58.0
+description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+home: https://github.com/kiali/kiali
+icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
+keywords:
+- istio
+- kiali
+maintainers:
+- email: kiali-users@googlegroups.com
+  name: Kiali
+  url: https://kiali.io
+name: kiali-server
+sources:
+- https://github.com/kiali/kiali
+- https://github.com/kiali/kiali-operator
+- https://github.com/kiali/helm-charts
+version: 1.58.0

--- a/charts/istio/charts/kiali-server/Chart.yaml
+++ b/charts/istio/charts/kiali-server/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
-appVersion: v1.58.0
-description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+appVersion: v1.54.0
+description: Kiali is an open source project for service mesh observability, refer
+  to https://www.kiali.io for details.
 home: https://github.com/kiali/kiali
 icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
 keywords:
@@ -15,4 +16,4 @@ sources:
 - https://github.com/kiali/kiali
 - https://github.com/kiali/kiali-operator
 - https://github.com/kiali/helm-charts
-version: 1.58.0
+version: 1.54.0

--- a/charts/istio/charts/kiali-server/templates/NOTES.txt
+++ b/charts/istio/charts/kiali-server/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Welcome to Kiali! For more details on Kiali, see: https://kiali.io
+
+The Kiali Server [{{ .Chart.AppVersion }}] has been installed in namespace [{{ .Release.Namespace }}]. It will be ready soon.
+
+(Helm: Chart=[{{ .Chart.Name }}], Release=[{{ .Release.Name }}], Version=[{{ .Chart.Version }}])

--- a/charts/istio/charts/kiali-server/templates/_helpers.tpl
+++ b/charts/istio/charts/kiali-server/templates/_helpers.tpl
@@ -1,0 +1,173 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified instance name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+To simulate the way the operator works, use deployment.instance_name rather than the old fullnameOverride.
+For backwards compatibility, if fullnameOverride is not kiali but deployment.instance_name is kiali,
+use fullnameOverride, otherwise use deployment.instance_name.
+*/}}
+{{- define "kiali-server.fullname" -}}
+{{- if (and (eq .Values.deployment.instance_name "kiali") (ne .Values.fullnameOverride "kiali")) }}
+  {{- .Values.fullnameOverride | trunc 63 }}
+{{- else }}
+  {{- .Values.deployment.instance_name | trunc 63 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kiali-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Identifies the log_level with the old verbose_mode and the new log_level considered.
+*/}}
+{{- define "kiali-server.logLevel" -}}
+{{- if .Values.deployment.verbose_mode -}}
+{{- .Values.deployment.verbose_mode -}}
+{{- else -}}
+{{- .Values.deployment.logger.log_level -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kiali-server.labels" -}}
+helm.sh/chart: {{ include "kiali-server.chart" . }}
+app: kiali
+{{ include "kiali-server.selectorLabels" . }}
+version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: "kiali"
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kiali-server.selectorLabels" -}}
+app.kubernetes.io/name: kiali
+app.kubernetes.io/instance: {{ include "kiali-server.fullname" . }}
+{{- end }}
+
+{{/*
+Determine the default login token signing key.
+*/}}
+{{- define "kiali-server.login_token.signing_key" -}}
+{{- if .Values.login_token.signing_key }}
+  {{- .Values.login_token.signing_key }}
+{{- else }}
+  {{- randAlphaNum 16 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the default web root.
+*/}}
+{{- define "kiali-server.server.web_root" -}}
+{{- if .Values.server.web_root  }}
+  {{- if (eq .Values.server.web_root "/") }}
+    {{- .Values.server.web_root }}
+  {{- else }}
+    {{- .Values.server.web_root | trimSuffix "/" }}
+  {{- end }}
+{{- else }}
+  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- "/" }}
+  {{- else }}
+    {{- "/kiali" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the default identity cert file. There is no default if on k8s; only on OpenShift.
+*/}}
+{{- define "kiali-server.identity.cert_file" -}}
+{{- if hasKey .Values.identity "cert_file" }}
+  {{- .Values.identity.cert_file }}
+{{- else }}
+  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- "/kiali-cert/tls.crt" }}
+  {{- else }}
+    {{- "" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the default identity private key file. There is no default if on k8s; only on OpenShift.
+*/}}
+{{- define "kiali-server.identity.private_key_file" -}}
+{{- if hasKey .Values.identity "private_key_file" }}
+  {{- .Values.identity.private_key_file }}
+{{- else }}
+  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- "/kiali-cert/tls.key" }}
+  {{- else }}
+    {{- "" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the default deployment.ingress.enabled. Disable it on k8s; enable it on OpenShift.
+*/}}
+{{- define "kiali-server.deployment.ingress.enabled" -}}
+{{- if hasKey .Values.deployment.ingress "enabled" }}
+  {{- .Values.deployment.ingress.enabled }}
+{{- else }}
+  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- true }}
+  {{- else }}
+    {{- false }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the istio namespace - default is where Kiali is installed.
+*/}}
+{{- define "kiali-server.istio_namespace" -}}
+{{- if .Values.istio_namespace }}
+  {{- .Values.istio_namespace }}
+{{- else }}
+  {{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the auth strategy to use - default is "token" on Kubernetes and "openshift" on OpenShift.
+*/}}
+{{- define "kiali-server.auth.strategy" -}}
+{{- if .Values.auth.strategy }}
+  {{- if (and (eq .Values.auth.strategy "openshift") (not .Values.kiali_route_url)) }}
+    {{- fail "You did not define what the Kiali Route URL will be (--set kiali_route_url=...). Without this set, the openshift auth strategy will not work. Either set that or use a different auth strategy via the --set auth.strategy=... option." }}
+  {{- end }}
+  {{- .Values.auth.strategy }}
+{{- else }}
+  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- if not .Values.kiali_route_url }}
+      {{- fail "You did not define what the Kiali Route URL will be (--set kiali_route_url=...). Without this set, the openshift auth strategy will not work. Either set that or explicitly indicate another auth strategy you want via the --set auth.strategy=... option." }}
+    {{- end }}
+    {{- "openshift" }}
+  {{- else }}
+    {{- "token" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the root namespace - default is where Kiali is installed.
+*/}}
+{{- define "kiali-server.external_services.istio.root_namespace" -}}
+{{- if .Values.external_services.istio.root_namespace }}
+  {{- .Values.external_services.istio.root_namespace }}
+{{- else }}
+  {{- .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/_helpers.tpl
+++ b/charts/istio/charts/kiali-server/templates/_helpers.tpl
@@ -171,3 +171,14 @@ Determine the root namespace - default is where Kiali is installed.
   {{- .Release.Namespace }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine the prometheus url - customized for so1s.
+*/}}
+{{- define "kiali-server.external_services.prometheus.url" -}}
+{{- if .Values.external_services.istio.root_namespace }}
+  {{- .Values.external_services.istio.root_namespace }}
+{{- else }}
+  {{- "http://prometheus.istio-system:9090" }}
+{{- end }}
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/cabundle.yaml
+++ b/charts/istio/charts/kiali-server/templates/cabundle.yaml
@@ -1,0 +1,13 @@
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-cabundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+...
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/configmap.yaml
+++ b/charts/istio/charts/kiali-server/templates/configmap.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  {{- if .Values.deployment.configmap_annotations }}
+  annotations:
+    {{- toYaml .Values.deployment.configmap_annotations | nindent 4 }}
+  {{- end }}
+data:
+  config.yaml: |
+    {{- /* Most of .Values is simply the ConfigMap - strip out the keys that are not part of the ConfigMap */}}
+    {{- $cm := omit .Values "nameOverride" "fullnameOverride" "kiali_route_url" }}
+    {{- /* The helm chart defines namespace for us, but pass it to the ConfigMap in case the server needs it */}}
+    {{- $_ := set $cm.deployment "namespace" .Release.Namespace }}
+    {{- /* Some values of the ConfigMap are generated, but might not be identical, from .Values */}}
+    {{- $_ := set $cm "istio_namespace" (include "kiali-server.istio_namespace" .) }}
+    {{- $_ := set $cm.auth "strategy" (include "kiali-server.auth.strategy" .) }}
+    {{- $_ := set $cm.auth.openshift "client_id_prefix" (include "kiali-server.fullname" .) }}
+    {{- $_ := set $cm.deployment "instance_name" (include "kiali-server.fullname" .) }}
+    {{- $_ := set $cm.identity "cert_file" (include "kiali-server.identity.cert_file" .) }}
+    {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
+    {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
+    {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
+    {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
+    {{- toYaml $cm | nindent 4 }}
+...

--- a/charts/istio/charts/kiali-server/templates/configmap.yaml
+++ b/charts/istio/charts/kiali-server/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
+    {{- $_ := set $cm.external_services.prometheus "url" (include "kiali-server.external_services.prometheus.url" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}
 ...

--- a/charts/istio/charts/kiali-server/templates/deployment.yaml
+++ b/charts/istio/charts/kiali-server/templates/deployment.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      {{- include "kiali-server.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      name: {{ include "kiali-server.fullname" . }}
+      labels:
+        {{- include "kiali-server.labels" . | nindent 8 }}
+        {{- if .Values.deployment.pod_labels }}
+        {{- toYaml .Values.deployment.pod_labels | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.server.metrics_enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.server.metrics_port | quote }}
+        {{- else }}
+        prometheus.io/scrape: "false"
+        prometheus.io/port: ""
+        {{- end }}
+        kiali.io/dashboards: go,kiali
+        {{- if .Values.deployment.pod_annotations }}
+        {{- toYaml .Values.deployment.pod_annotations | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "kiali-server.fullname" . }}
+      {{- if .Values.deployment.priority_class_name }}
+      priorityClassName: {{ .Values.deployment.priority_class_name | quote }}
+      {{- end }}
+      {{- if .Values.deployment.image_pull_secrets }}
+      imagePullSecrets:
+      {{- range .Values.deployment.image_pull_secrets }}
+      - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.deployment.host_aliases }}
+      hostAliases:
+      {{- toYaml .Values.deployment.host_aliases | nindent 6 }}
+      {{- end }}
+      containers:
+      - image: "{{ .Values.deployment.image_name }}{{ if .Values.deployment.image_digest }}@{{ .Values.deployment.image_digest }}{{ end }}:{{ .Values.deployment.image_version }}"
+        imagePullPolicy: {{ .Values.deployment.image_pull_policy | default "Always" }}
+        name: {{ include "kiali-server.fullname" . }}
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        securityContext:
+        {{- if .Values.deployment.security_context}}
+        {{- toYaml .Values.deployment.security_context | nindent 10 }}
+        {{- else }}
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
+        ports:
+        - name: api-port
+          containerPort: {{ .Values.server.port | default 20001 }}
+        {{- if .Values.server.metrics_enabled }}
+        - name: http-metrics
+          containerPort: {{ .Values.server.metrics_port | default 9090 }}
+        {{- end }}
+        readinessProbe:
+          httpGet:
+            path: {{ include "kiali-server.server.web_root" . | trimSuffix "/"  }}/healthz
+            port: api-port
+            {{- if (include "kiali-server.identity.cert_file" .) }}
+            scheme: HTTPS
+            {{- else }}
+            scheme: HTTP
+            {{- end }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          httpGet:
+            path: {{ include "kiali-server.server.web_root" . | trimSuffix "/"  }}/healthz
+            port: api-port
+            {{- if (include "kiali-server.identity.cert_file" .) }}
+            scheme: HTTPS
+            {{- else }}
+            scheme: HTTP
+            {{- end }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOG_LEVEL
+          value: "{{ include "kiali-server.logLevel" . }}"
+        - name: LOG_FORMAT
+          value: "{{ .Values.deployment.logger.log_format }}"
+        - name: LOG_TIME_FIELD_FORMAT
+          value: "{{ .Values.deployment.logger.time_field_format }}"
+        - name: LOG_SAMPLER_RATE
+          value: "{{ .Values.deployment.logger.sampler_rate }}"
+        volumeMounts:
+        - name: {{ include "kiali-server.fullname" . }}-configuration
+          mountPath: "/kiali-configuration"
+        - name: {{ include "kiali-server.fullname" . }}-cert
+          mountPath: "/kiali-cert"
+        - name: {{ include "kiali-server.fullname" . }}-secret
+          mountPath: "/kiali-secret"
+        - name: {{ include "kiali-server.fullname" . }}-cabundle
+          mountPath: "/kiali-cabundle"
+        {{- range .Values.deployment.custom_secrets }}
+        - name: {{ .name }}
+          mountPath: "{{ .mount }}"
+        {{- end }}
+        {{- if .Values.deployment.resources }}
+        resources:
+        {{- toYaml .Values.deployment.resources | nindent 10 }}
+        {{- end }}
+      volumes:
+      - name: {{ include "kiali-server.fullname" . }}-configuration
+        configMap:
+          name: {{ include "kiali-server.fullname" . }}
+      - name: {{ include "kiali-server.fullname" . }}-cert
+        secret:
+          {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+          secretName: {{ include "kiali-server.fullname" . }}-cert-secret
+          {{- else }}
+          secretName: istio.{{ include "kiali-server.fullname" . }}-service-account
+          {{- end }}
+          {{- if not (include "kiali-server.identity.cert_file" .) }}
+          optional: true
+          {{- end }}
+      - name: {{ include "kiali-server.fullname" . }}-secret
+        secret:
+          secretName: {{ .Values.deployment.secret_name }}
+          optional: true
+      - name: {{ include "kiali-server.fullname" . }}-cabundle
+        configMap:
+          name: {{ include "kiali-server.fullname" . }}-cabundle
+      {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+          optional: true
+      {{- end }}
+      {{- range .Values.deployment.custom_secrets }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .name }}
+          optional: {{ .optional | default false }}
+      {{- end }}
+      {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}
+      affinity:
+        {{- if .Values.deployment.affinity.node }}
+        nodeAffinity:
+        {{- toYaml .Values.deployment.affinity.node | nindent 10 }}
+        {{- end }}
+        {{- if .Values.deployment.affinity.pod }}
+        podAffinity:
+        {{- toYaml .Values.deployment.affinity.pod | nindent 10 }}
+        {{- end }}
+        {{- if .Values.deployment.affinity.pod_anti }}
+        podAntiAffinity:
+        {{- toYaml .Values.deployment.affinity.pod_anti | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.deployment.tolerations }}
+      tolerations:
+      {{- toYaml .Values.deployment.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.node_selector }}
+      nodeSelector:
+      {{- toYaml .Values.deployment.node_selector | nindent 8 }}
+      {{- end }}
+...

--- a/charts/istio/charts/kiali-server/templates/deployment.yaml
+++ b/charts/istio/charts/kiali-server/templates/deployment.yaml
@@ -62,17 +62,10 @@ spec:
         - "-config"
         - "/kiali-configuration/config.yaml"
         securityContext:
-        {{- if .Values.deployment.security_context}}
-        {{- toYaml .Values.deployment.security_context | nindent 10 }}
-        {{- else }}
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-        {{- end }}
         ports:
         - name: api-port
           containerPort: {{ .Values.server.port | default 20001 }}

--- a/charts/istio/charts/kiali-server/templates/deployment.yaml
+++ b/charts/istio/charts/kiali-server/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- toYaml .Values.deployment.pod_labels | nindent 8 }}
         {{- end }}
       annotations:
+        sidecar.istio.io/inject: "true"
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.server.metrics_enabled }}
         prometheus.io/scrape: "true"

--- a/charts/istio/charts/kiali-server/templates/hpa.yaml
+++ b/charts/istio/charts/kiali-server/templates/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.deployment.hpa.spec }}
+---
+apiVersion: {{ .Values.deployment.hpa.api_version }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kiali-server.fullname" . }}
+  {{- toYaml .Values.deployment.hpa.spec | nindent 2 }}
+...
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/ingress.yaml
+++ b/charts/istio/charts/kiali-server/templates/ingress.yaml
@@ -1,0 +1,62 @@
+{{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+{{- if eq "true" (include "kiali-server.deployment.ingress.enabled" .) }}
+---
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- if .Values.deployment.ingress.additional_labels }}
+    {{- toYaml .Values.deployment.ingress.additional_labels | nindent 4 }}
+    {{- end }}
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.deployment.ingress.override_yaml.metadata.annotations }}
+    {{- toYaml .Values.deployment.ingress.override_yaml.metadata.annotations | nindent 4 }}
+    {{- else }}
+    # For ingress-nginx versions older than 0.20.0 use secure-backends.
+    # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
+    # For ingress-nginx versions 0.20.0 and later use backend-protocol.
+    {{- if (include "kiali-server.identity.cert_file" .) }}
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    {{- else }}
+    nginx.ingress.kubernetes.io/secure-backends: "false"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if hasKey .Values.deployment.ingress.override_yaml "spec" }}
+  {{- toYaml .Values.deployment.ingress.override_yaml.spec | nindent 2 }}
+  {{- else }}
+  {{- if .Values.deployment.ingress.class_name }}
+  ingressClassName: {{ .Values.deployment.ingress.class_name }}
+  {{- end }}
+  rules:
+  - http:
+      paths:
+      - path: {{ include "kiali-server.server.web_root" . }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "kiali-server.fullname" . }}
+            port:
+              number: {{ .Values.server.port }}
+        {{- else }}
+        backend:
+          serviceName: {{ include "kiali-server.fullname" . }}
+          servicePort: {{ .Values.server.port }}
+        {{- end }}
+    {{- if not (empty .Values.server.web_fqdn) }}
+    host: {{ .Values.server.web_fqdn }}
+    {{- end }}
+  {{- end }}
+...
+{{- end }}
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/oauth.yaml
+++ b/charts/istio/charts/kiali-server/templates/oauth.yaml
@@ -1,0 +1,17 @@
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+{{- if .Values.kiali_route_url }}
+---
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+redirectURIs:
+- {{ .Values.kiali_route_url }}
+grantMethod: auto
+allowAnyScope: true
+...
+{{- end }}
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/role-controlplane.yaml
+++ b/charts/istio/charts/kiali-server/templates/role-controlplane.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-controlplane
+  namespace: {{ include "kiali-server.istio_namespace" . }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+rules:
+{{- if .Values.kiali_feature_flags.clustering.enabled }}
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - list
+{{- end }}
+{{- if .Values.kiali_feature_flags.certificates_information_indicators.enabled }}
+- apiGroups: [""]
+  resourceNames:
+  {{- range .Values.kiali_feature_flags.certificates_information_indicators.secrets }}
+  - {{ . }}
+  {{- end }}
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+...

--- a/charts/istio/charts/kiali-server/templates/role-viewer.yaml
+++ b/charts/istio/charts/kiali-server/templates/role-viewer.yaml
@@ -54,9 +54,6 @@ rules:
 - apiGroups:
   - networking.istio.io
   - security.istio.io
-  - extensions.istio.io
-  - telemetry.istio.io
-  - gateway.networking.k8s.io
   resources: ["*"]
   verbs:
   - get

--- a/charts/istio/charts/kiali-server/templates/role-viewer.yaml
+++ b/charts/istio/charts/kiali-server/templates/role-viewer.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-viewer
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+{{- if not (has "logs-tab" .Values.kiali_feature_flags.disabled_features) }}
+  - pods/log
+{{- end }}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+...

--- a/charts/istio/charts/kiali-server/templates/role.yaml
+++ b/charts/istio/charts/kiali-server/templates/role.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+{{- if not (has "logs-tab" .Values.kiali_feature_flags.disabled_features) }}
+  - pods/log
+{{- end }}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io 
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+...

--- a/charts/istio/charts/kiali-server/templates/role.yaml
+++ b/charts/istio/charts/kiali-server/templates/role.yaml
@@ -57,9 +57,6 @@ rules:
 - apiGroups:
   - networking.istio.io
   - security.istio.io
-  - extensions.istio.io
-  - telemetry.istio.io
-  - gateway.networking.k8s.io 
   resources: ["*"]
   verbs:
   - get

--- a/charts/istio/charts/kiali-server/templates/rolebinding-controlplane.yaml
+++ b/charts/istio/charts/kiali-server/templates/rolebinding-controlplane.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-controlplane
+  namespace: {{ include "kiali-server.istio_namespace" . }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kiali-server.fullname" . }}-controlplane
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+...

--- a/charts/istio/charts/kiali-server/templates/rolebinding.yaml
+++ b/charts/istio/charts/kiali-server/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  {{- if .Values.deployment.view_only_mode }}
+  name: {{ include "kiali-server.fullname" . }}-viewer
+  {{- else }}
+  name: {{ include "kiali-server.fullname" . }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+...

--- a/charts/istio/charts/kiali-server/templates/route.yaml
+++ b/charts/istio/charts/kiali-server/templates/route.yaml
@@ -1,0 +1,34 @@
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+{{- if eq "true" (include "kiali-server.deployment.ingress.enabled" .) }}
+# As of OpenShift 4.5, need to use --disable-openapi-validation when installing via Helm
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- if .Values.deployment.ingress.additional_labels }}
+    {{- toYaml .Values.deployment.ingress.additional_labels | nindent 4 }}
+    {{- end }}
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  {{- if .Values.deployment.ingress.override_yaml.metadata.annotations }}
+  annotations:
+  {{- toYaml .Values.deployment.ingress.override_yaml.metadata.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if hasKey .Values.deployment.ingress.override_yaml "spec" }}
+  {{- toYaml .Values.deployment.ingress.override_yaml.spec | nindent 2 }}
+  {{- else }}
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: {{ include "kiali-server.fullname" . }}
+  port:
+    targetPort: {{ .Values.server.port }}
+  {{- end }}
+...
+{{- end }}
+{{- end }}

--- a/charts/istio/charts/kiali-server/templates/service.yaml
+++ b/charts/istio/charts/kiali-server/templates/service.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    service.beta.openshift.io/serving-cert-secret-name: {{ include "kiali-server.fullname" . }}-cert-secret
+    {{- end }}
+    {{- if and (not (empty .Values.server.web_fqdn)) (not (empty .Values.server.web_schema)) }}
+    {{- if empty .Values.server.web_port }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}{{ include "kiali-server.server.web_root" . }}
+    {{- else }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}:{{ .Values.server.web_port }}{{ include "kiali-server.server.web_root" . }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.deployment.service_annotations }}
+    {{- toYaml .Values.deployment.service_annotations | nindent 4  }}
+    {{- end }}
+spec:
+  {{- if .Values.deployment.service_type }}
+  type: {{ .Values.deployment.service_type }}
+  {{- end }}
+  ports:
+  {{- if (include "kiali-server.identity.cert_file" .) }}
+  - name: tcp
+  {{- else }}
+  - name: http
+  {{- end }}
+    protocol: TCP
+    port: {{ .Values.server.port }}
+  {{- if .Values.server.metrics_enabled }}
+  - name: http-metrics
+    protocol: TCP
+    port: {{ .Values.server.metrics_port }}
+  {{- end }}
+  selector:
+    {{- include "kiali-server.selectorLabels" . | nindent 4 }}
+  {{- if .Values.deployment.additional_service_yaml }}
+  {{- toYaml .Values.deployment.additional_service_yaml | nindent 2  }}
+  {{- end }}
+...

--- a/charts/istio/charts/kiali-server/templates/serviceaccount.yaml
+++ b/charts/istio/charts/kiali-server/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+...

--- a/charts/istio/charts/kiali-server/values.yaml
+++ b/charts/istio/charts/kiali-server/values.yaml
@@ -81,6 +81,8 @@ external_services:
     enabled: true
   istio:
     root_namespace: ""
+  prometheus:
+    url: http://monitoring-kube-prometheus-prometheus.monitoring:9090
 
 identity: {}
   #cert_file:

--- a/charts/istio/charts/kiali-server/values.yaml
+++ b/charts/istio/charts/kiali-server/values.yaml
@@ -1,0 +1,109 @@
+# 'fullnameOverride' is deprecated. Use 'deployment.instance_name' instead.
+# This is only supported for backward compatibility and will be removed in a future version.
+# If 'fullnameOverride' is not "kiali" and 'deployment.instance_name' is "kiali",
+# then 'deployment.instance_name' will take the value of 'fullnameOverride' value.
+# Otherwise, 'fullnameOverride' is ignored and 'deployment.instance_name' is used.
+fullnameOverride: "kiali"
+
+# This is required for "openshift" auth strategy.
+# You have to know ahead of time what your Route URL will be because
+# right now the helm chart can't figure this out at runtime (it would
+# need to wait for the Kiali Route to be deployed and for OpenShift
+# to start it up). If someone knows how to update this helm chart to
+# do this, a PR would be welcome.
+kiali_route_url: ""
+
+#
+# Settings that mimic the Kiali CR which are placed in the ConfigMap.
+# Note that only those values used by the Helm Chart will be here.
+#
+
+istio_namespace: "" # default is where Kiali is installed
+
+auth:
+  openid: {}
+  openshift: {}
+  strategy: ""
+
+deployment:
+  # This only limits what Kiali will attempt to see, but Kiali Service Account has permissions to see everything.
+  # For more control over what the Kial Service Account can see, use the Kiali Operator
+  accessible_namespaces:
+  - "**"
+  additional_service_yaml: {}
+  affinity:
+    node: {}
+    pod: {}
+    pod_anti: {}
+  configmap_annotations: {}
+  custom_secrets: []
+  host_aliases: []
+  hpa:
+    api_version: "autoscaling/v2"
+    spec: {}
+  image_digest: "" # use "sha256" if image_version is a sha256 hash (do NOT prefix this value with a "@")
+  image_name: quay.io/kiali/kiali
+  image_pull_policy: "Always"
+  image_pull_secrets: []
+  image_version: v1.58.0 # version like "v1.39" (see: https://quay.io/repository/kiali/kiali?tab=tags) or a digest hash
+  ingress:
+    additional_labels: {}
+    class_name: "nginx"
+    #enabled:
+    override_yaml:
+      metadata: {}
+  instance_name: "kiali"
+  logger:
+    log_format: "text"
+    log_level: "info"
+    time_field_format: "2006-01-02T15:04:05Z07:00"
+    sampler_rate: "1"
+  node_selector: {}
+  pod_annotations: {}
+  pod_labels: {}
+  priority_class_name: ""
+  replicas: 1
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "64Mi"
+    limits:
+      memory: "1Gi"
+  secret_name: "kiali"
+  security_context: {}
+  service_annotations: {}
+  service_type: ""
+  tolerations: []
+  version_label: v1.58.0 # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
+  view_only_mode: false
+
+external_services:
+  custom_dashboards:
+    enabled: true
+  istio:
+    root_namespace: ""
+
+identity: {}
+  #cert_file:
+  #private_key_file:
+
+kiali_feature_flags:
+  certificates_information_indicators:
+    enabled: true
+    secrets:
+    - cacerts
+    - istio-ca-secret
+  clustering:
+    enabled: true
+  disabled_features: []
+  validations:
+    ignore: ["KIA1201"]
+
+login_token:
+  signing_key: ""
+
+server:
+  port: 20001
+  metrics_enabled: true
+  metrics_port: 9090
+  web_root: ""

--- a/charts/istio/charts/kiali-server/values.yaml
+++ b/charts/istio/charts/kiali-server/values.yaml
@@ -45,7 +45,7 @@ deployment:
   image_name: quay.io/kiali/kiali
   image_pull_policy: "Always"
   image_pull_secrets: []
-  image_version: v1.58.0 # version like "v1.39" (see: https://quay.io/repository/kiali/kiali?tab=tags) or a digest hash
+  image_version: v1.54.0 # version like "v1.39" (see: https://quay.io/repository/kiali/kiali?tab=tags) or a digest hash
   ingress:
     additional_labels: {}
     class_name: "nginx"
@@ -70,11 +70,10 @@ deployment:
     limits:
       memory: "1Gi"
   secret_name: "kiali"
-  security_context: {}
   service_annotations: {}
   service_type: ""
   tolerations: []
-  version_label: v1.58.0 # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
+  version_label: v1.54.0 # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
   view_only_mode: false
 
 external_services:

--- a/charts/istio/templates/kiali/gateway.yaml
+++ b/charts/istio/templates/kiali/gateway.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+      {{ toYaml .Values.kiali.gateway.hosts | indent 4 }}
+  - port:
+      number: 9443
+      name: http-dev
+      protocol: HTTP
+    hosts:
+      {{ toYaml .Values.kiali.gateway.hosts | indent 4 }}

--- a/charts/istio/templates/kiali/virtualservice.yaml
+++ b/charts/istio/templates/kiali/virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  hosts:
+    {{ toYaml .Values.kiali.gateway.hosts | indent 4 }}
+  gateways:
+  - kibana
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        port:
+          number: 20001
+        host: kiali

--- a/charts/istio/templates/kiali/virtualservice.yaml
+++ b/charts/istio/templates/kiali/virtualservice.yaml
@@ -7,7 +7,7 @@ spec:
   hosts:
     {{ toYaml .Values.kiali.gateway.hosts | indent 4 }}
   gateways:
-  - kibana
+  - kiali
   http:
   - match:
     - uri:

--- a/charts/istio/values.yaml
+++ b/charts/istio/values.yaml
@@ -9,6 +9,10 @@ ingress:
 istio-gateway: {}
 istiod: {}
 
+kiali:
+  gateway:
+    hosts:
+      - kiali.so1s.io
 
 preInstall:
   tolerations: []

--- a/charts/monitoring/Chart.lock
+++ b/charts/monitoring/Chart.lock
@@ -9,10 +9,10 @@ dependencies:
   repository: file://./charts/grafana
   version: 6.32.2
 - name: metrics-server
-  repository: https://kubernetes-sigs.github.io/metrics-server/
+  repository: https://kubernetes-sigs.github.io/metrics-server
   version: 3.8.2
 - name: prometheus-adapter
   repository: https://prometheus-community.github.io/helm-charts
   version: 3.4.1
-digest: sha256:c147dab6943d7c27a02dfaabecf834de135a71ea5231b0053140e9752ac2f0ba
-generated: "2022-10-25T18:39:43.312251+09:00"
+digest: sha256:5bddc0e9bd90a18221818559f4c0f3ebc9531a1faef1315da880b96933cc9865
+generated: "2022-11-03T09:55:06.862309962+09:00"

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   version: 6.32.*
 - condition: metrics-server.enabled
   name: metrics-server
-  repository: https://kubernetes-sigs.github.io/metrics-server/
+  repository: https://kubernetes-sigs.github.io/metrics-server
   version: 3.8.*
 - condition: prometheus-adapter.enabled
   name: prometheus-adapter

--- a/root-dev.yaml
+++ b/root-dev.yaml
@@ -13,7 +13,7 @@ spec:
 
   # Source of the application manifests
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: main
     path: apps/dev
 

--- a/root-prod.yaml
+++ b/root-prod.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: https://github.com/So1S/deploy.git
+    repoURL: https://github.com/so1s/so1s-deploy.git
     targetRevision: release/v1.0.0
     path: apps/prod
 


### PR DESCRIPTION
# Tracing Service Kiali 연동


## Tasks

- [x] Istio 차트 내부에 Kiali dependency 세팅
- [x] Istio Gateway, VirtualService 구성
- [x] Istio와 호환되는 Kiali 버전으로 다운그레이드
- [x] Monitoring 차트에서 제공하고 있는 Prometheus svc url로 kiali 서버 커스텀
- [x] Org, Repo 이름 변경으로 인한 url 수정


## Discussion

- 추후 프로덕션 클러스터에서 작동 확인을 할 예정입니다.
- 추후 프론트엔드에서 kiali.so1s.io로 연동해주는 Navbar를 작성하는 대응 PR이 필요합니다. 머지 이후에 작업하겠습니다.
- Kiali에 접근하기 위해서는 토큰이 필요합니다. kubectl을 통해 가져올 수 있고, 문서화 되어있는 부분인 infra 레포 리드미에 매뉴얼을 작성하였습니다.
    - https://github.com/so1s/so1s-infra/tree/main/live#kiali-%ED%86%A0%ED%81%B0-%ED%99%95%EC%9D%B8


## References

- https://kiali.io/docs/installation/installation-guide/prerequisites/
- https://stackoverflow.com/a/67877571/11853111


## Jira

- SO1S-478