### PR TITLE
SO1S-482 ABN 테스트 개발 대응 Backend 라우팅 버전 명시 제거

### DIFF
--- a/charts/frontend/dev-values.yaml
+++ b/charts/frontend/dev-values.yaml
@@ -57,7 +57,7 @@ config:
         try_files $uri /index.html;
       }
 
-      location /api/v1 {
+      location /api {
         proxy_pass http://so1s-dev.backend.svc.cluster.local:80;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;

--- a/charts/frontend/prod-values.yaml
+++ b/charts/frontend/prod-values.yaml
@@ -53,7 +53,7 @@ config:
         try_files $uri /index.html;
       }
 
-      location /api/v1 {
+      location /api {
         proxy_pass http://so1s-prod.backend.svc.cluster.local:80;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;


### PR DESCRIPTION
# ABN 테스트 개발 대응 Backend 라우팅 버전 명시 제거


## Tasks

- [x] 백엔드로 가는 nginx 리버스 프록시 라우팅을 /api/v1 -> /api로 변경


## Discussion

- SO1S-482 백엔드 PR에서 /api/v2 라우팅을 사용하고 있기 때문에, 버전 명시를 지정해주지 않은 라우팅으로 Prefix를 수정하였습니다.
  - https://github.com/so1s/so1s-backend/pull/65


## Jira

- SO1S-482